### PR TITLE
Implicit conversion of codepoint to underlying type

### DIFF
--- a/include/text_view_detail/character.hpp
+++ b/include/text_view_detail/character.hpp
@@ -48,6 +48,11 @@ public:
         return code_point;
     }
 
+    operator code_point_type() const noexcept {
+        return code_point;
+    }
+
+
     static character_set_id get_character_set_id() {
         return std::experimental::text::get_character_set_id<CST>();
     }


### PR DESCRIPTION
Implicit conversion of character/code-point to the underlying codepoint type makes using text_views with interfaces expecting a range of codepoints easier.

 